### PR TITLE
:bug::wrench:修复因缺少ModuleConfig.module导致的应用启动失败问题

### DIFF
--- a/client/src/main/resources/application.properties
+++ b/client/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.dubbo.application.name=consumer
 spring.dubbo.registry.address=zookeeper://192.168.99.100:32770
 spring.dubbo.scan=cn.teaey.sprintboot.test
+spring.dubbo.module.default=false

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.dubbo.registry.address=zookeeper://192.168.99.100:32770
 spring.dubbo.protocol.name=dubbo
 spring.dubbo.protocol.port=20880
 spring.dubbo.scan=cn.teaey.sprintboot.test
+spring.dubbo.module.default=false


### PR DESCRIPTION
## 修复因缺少ModuleConfig.module导致的应用启动失败问题
如果没有设置module属性，应用会在启动时失败并包`ModuleConfig.module == null `错误