### PR TITLE
对应PR-324 spring-boot-starter-dubbo 所做的调整

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dubbo-starter</artifactId>
         <groupId>cn.teaey.sprintboot.test</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/api/src/main/java/cn/teaey/springboot/test/EchoService.java
+++ b/api/src/main/java/cn/teaey/springboot/test/EchoService.java
@@ -1,4 +1,4 @@
-package cn.teaey.sprintboot.test;
+package cn.teaey.springboot.test;
 
 /**
  * @author xiaofei.wxf(teaey)

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dubbo-starter</artifactId>
         <groupId>cn.teaey.sprintboot.test</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,11 +15,15 @@
         <dependency>
             <groupId>cn.teaey.sprintboot.test</groupId>
             <artifactId>api</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dubbo.springboot</groupId>
             <artifactId>spring-boot-starter-dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
         </dependency>
     </dependencies>
 
@@ -28,7 +32,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${springboot.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/client/src/main/java/cn/teaey/springboot/test/AbcService.java
+++ b/client/src/main/java/cn/teaey/springboot/test/AbcService.java
@@ -1,4 +1,4 @@
-package cn.teaey.sprintboot.test;
+package cn.teaey.springboot.test;
 
 import com.alibaba.dubbo.config.annotation.Reference;
 import org.springframework.stereotype.Component;

--- a/client/src/main/java/cn/teaey/springboot/test/Client.java
+++ b/client/src/main/java/cn/teaey/springboot/test/Client.java
@@ -1,4 +1,4 @@
-package cn.teaey.sprintboot.test;
+package cn.teaey.springboot.test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,6 +13,7 @@ public class Client {
     public static void main(String[] args) {
         ConfigurableApplicationContext run = SpringApplication.run(Client.class, args);
         AbcService bean = run.getBean(AbcService.class);
-        System.out.println(bean.echoService.echo("abccc"));
+        String result = bean.echoService.echo( "abccc" );
+        System.out.println( result );
     }
 }

--- a/client/src/main/resources/application.properties
+++ b/client/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.dubbo.application.name=consumer
 spring.dubbo.registry.address=zookeeper://localhost:2181
-spring.dubbo.scan=cn.teaey.sprintboot.test
+spring.dubbo.scan=cn.teaey.springboot.test
 spring.dubbo.module.default=false
+# tomcat 所占端口号
+server.port = 8081

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.5.RELEASE</version>
+        <version>1.5.8.RELEASE</version>
     </parent>
     <groupId>cn.teaey.sprintboot.test</groupId>
     <artifactId>dubbo-starter</artifactId>
@@ -19,21 +19,24 @@
     <packaging>pom</packaging>
     <properties>
         <java.version>1.7</java.version>
-        <springboot.version>1.3.5.RELEASE</springboot.version>
+        <springboot.version>1.5.8.RELEASE</springboot.version>
+        <spring-boot-starter-dubbo.version>1.0.0</spring-boot-starter-dubbo.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.dubbo.springboot</groupId>
                 <artifactId>spring-boot-starter-dubbo</artifactId>
-                <version>1.0.0</version>
+                <version>${spring-boot-starter-dubbo.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-web</artifactId>
+                <artifactId>spring-boot</artifactId>
                 <version>${springboot.version}</version>
             </dependency>
         </dependencies>
+
     </dependencyManagement>
+
 
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dubbo-starter</artifactId>
         <groupId>cn.teaey.sprintboot.test</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,11 +15,15 @@
         <dependency>
             <groupId>cn.teaey.sprintboot.test</groupId>
             <artifactId>api</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dubbo.springboot</groupId>
             <artifactId>spring-boot-starter-dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -27,7 +31,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${springboot.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/server/src/main/java/cn/teaey/springboot/test/EchoServerImpl.java
+++ b/server/src/main/java/cn/teaey/springboot/test/EchoServerImpl.java
@@ -1,4 +1,4 @@
-package cn.teaey.sprintboot.test;
+package cn.teaey.springboot.test;
 
 import com.alibaba.dubbo.config.annotation.Service;
 

--- a/server/src/main/java/cn/teaey/springboot/test/Server.java
+++ b/server/src/main/java/cn/teaey/springboot/test/Server.java
@@ -1,4 +1,4 @@
-package cn.teaey.sprintboot.test;
+package cn.teaey.springboot.test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,7 +3,9 @@ spring.dubbo.registry.address=zookeeper://localhost:2181
 spring.dubbo.protocol.name=dubbo
 spring.dubbo.protocol.port=20880
 ## 本机的IP地址
- spring.dubbo.protocol.host=192.168.1.102
-spring.dubbo.scan=cn.teaey.sprintboot.test
+spring.dubbo.protocol.host=localhost
+spring.dubbo.scan=cn.teaey.springboot.test
 ## 设置Module
 spring.dubbo.module.default=false
+# tomcat 所占端口号
+server.port = 8080


### PR DESCRIPTION
1、修改spring boot版本为最新版本1.5.8.RELEASE
2、修改服务端和客户端的一些spring boot 配置，如zk adddress、tomcat server port、tomcat client port 方便在一个机器跑起来demo
3、修改maven依赖配置，解决demo不能运行的问题